### PR TITLE
Fix confusing behavior

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "Coquille"
-version = "1.0.2"
+version = "1.1.0"
 authors = [{ name = "Qexat" }]
 description = "Coquille is a library that wraps terminal escape sequences as convenient functions."
 readme = "README.md"

--- a/src/coquille/coquille.py
+++ b/src/coquille/coquille.py
@@ -1,11 +1,12 @@
 # pyright: reportUnusedCallResult = false
 from __future__ import annotations
-from abc import abstractmethod
 
 import sys
+from abc import abstractmethod
 from collections.abc import Callable
 from dataclasses import dataclass
-from typing import Protocol, overload
+from typing import overload
+from typing import Protocol
 from typing import TYPE_CHECKING
 
 from coquille.sequences import EscapeSequence

--- a/src/coquille/typeshed.py
+++ b/src/coquille/typeshed.py
@@ -2,6 +2,7 @@
 Typeshed stuff that Coquille needs but that are not available
 on the Python standard library.
 """
+from abc import abstractmethod
 from typing import Protocol
 from typing import TypeVar
 
@@ -10,8 +11,9 @@ _T_contra = TypeVar("_T_contra", contravariant=True)
 
 
 class SupportsWrite(Protocol[_T_contra]):
+    @abstractmethod
     def write(self, __s: _T_contra) -> object:
-        ...
+        pass
 
 
 Self = TypeVar("Self")


### PR DESCRIPTION
* New `CoquilleLike` interface to avoid code duplication
* `_ContextCoquille` attributes are now "public" (to implement `CoquilleLike` correctly)
even though the class itself is private
* `Coquille` has now a `print` method (same as `_ContextCoquille`'s one)
* `Coquille.write()` has breaking changes: it is no longer a
staticmethod (see `write` function instead), and uses the coquille's registered
sequences
* The standalone `write` function is not an alias of
`Coquille.write()` anymore
* Bump to 1.1.0